### PR TITLE
Add a mutex per key, use same storeMutex across all stores

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -107,17 +107,20 @@ func (h *Handler) storeResource(r *http.Request, res *Resource) {
 	Writes.Add(1)
 
 	go func() {
+		defer Writes.Done()
 		res.Save(RequestKey(r), h.store)
 
 		// Secondary store for vary
 		if vary := res.Header.Get("Vary"); vary != "" {
-			h.store.Copy(
+			_, err := store.Copy(
 				VaryKey(res.Header.Get("Vary"), r),
 				RequestKey(r),
+				h.store,
 			)
+			if err != nil {
+				log.Println(err)
+			}
 		}
-
-		Writes.Done()
 	}()
 }
 

--- a/store/filestore.go
+++ b/store/filestore.go
@@ -6,12 +6,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 )
 
 type FileStore struct {
 	dir       string
-	mutex     sync.RWMutex
+	mutex     *storeMutex
 	FileNamer func(k string) string
 }
 
@@ -20,16 +19,15 @@ func NewFileStore(dir string) (*FileStore, error) {
 		return nil, err
 	}
 
-	return &FileStore{dir: dir, FileNamer: func(k string) string {
-		h := md5.New()
-		io.WriteString(h, k)
-		return fmt.Sprintf("%x", h.Sum(nil))
-	}}, nil
+	return &FileStore{
+		dir: dir, FileNamer: md5Namer, mutex: newStoreMutex(),
+	}, nil
 }
 
 func (fs *FileStore) Has(key string) bool {
-	fs.mutex.RLock()
-	defer fs.mutex.RUnlock()
+	mutex := fs.mutex.ForKey(key)
+	mutex.RLock()
+	defer mutex.RUnlock()
 
 	if _, err := fs.file(key, os.O_RDONLY); err != nil {
 		return false
@@ -37,30 +35,10 @@ func (fs *FileStore) Has(key string) bool {
 	return true
 }
 
-func (fs *FileStore) Copy(dest, src string) error {
-	fs.mutex.Lock()
-	defer fs.mutex.Unlock()
-
-	s, err := fs.file(src, os.O_RDONLY)
-	if err != nil {
-		return err
-	}
-	defer s.Close()
-	d, err := fs.file(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(d, s); err != nil {
-		d.Close()
-		return err
-	}
-
-	return d.Close()
-}
-
 func (fs *FileStore) Delete(key string) error {
-	fs.mutex.Lock()
-	defer fs.mutex.Unlock()
+	mutex := fs.mutex.ForKey(key)
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	err := os.Remove(fs.filePath(key))
 	if err != nil && os.IsNotExist(err) {
@@ -69,30 +47,29 @@ func (fs *FileStore) Delete(key string) error {
 	return err
 }
 
-func (fs *FileStore) ReadStream(key string) (io.ReadCloser, error) {
-	fs.mutex.RLock()
+func (fs *FileStore) Reader(key string) (io.ReadCloser, error) {
+	mutex := fs.mutex.ForKey(key)
+	mutex.RLock()
 
 	f, err := fs.file(key, os.O_RDONLY)
 	if err != nil {
-		fs.mutex.RUnlock()
+		mutex.RUnlock()
 		return nil, err
 	}
-	return &fileCloser{f, &fs.mutex}, nil
+
+	return mutex.ReadCloser(f), nil
 }
 
-func (fs *FileStore) WriteStream(key string, r io.Reader) error {
-	fs.mutex.Lock()
-	defer fs.mutex.Unlock()
+func (fs *FileStore) Writer(key string) (io.WriteCloser, error) {
+	mutex := fs.mutex.ForKey(key)
+	mutex.Lock()
 
 	f, err := fs.file(key, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
-		return err
-	}
-	if _, err = io.Copy(f, r); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return mutex.WriteCloser(f), nil
 }
 
 func (fs *FileStore) filePath(key string) string {
@@ -101,24 +78,20 @@ func (fs *FileStore) filePath(key string) string {
 
 func (fs *FileStore) file(key string, flags int) (*os.File, error) {
 	f, err := os.OpenFile(fs.filePath(key), flags, 0777)
-	if err != nil && os.IsNotExist(err) {
-		return f, ErrNotExists
-	} else if err != nil {
-		return f, err
+
+	if os.IsNotExist(err) {
+		return nil, ErrNotExists
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return f, nil
 }
 
-type fileCloser struct {
-	*os.File
-	readMutex *sync.RWMutex
-}
-
-func (fc *fileCloser) Close() error {
-	defer fc.readMutex.RUnlock()
-	if err := fc.File.Close(); err != nil {
-		return err
-	}
-	return nil
+func md5Namer(key string) string {
+	h := md5.New()
+	io.WriteString(h, key)
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/store/filestore_test.go
+++ b/store/filestore_test.go
@@ -25,6 +25,6 @@ func TestFileStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tester := &storeTester{}
+	tester := &storeTester{s}
 	tester.Test(t)
 }

--- a/store/mutex.go
+++ b/store/mutex.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"io"
+	"log"
+	"runtime"
+	"sync"
+)
+
+var debugMutex bool
+
+type storeMutex struct {
+	entries map[string]*keyMutex
+	mutex   sync.Mutex
+}
+
+func newStoreMutex() *storeMutex {
+	return &storeMutex{
+		entries: map[string]*keyMutex{},
+	}
+}
+
+func (m *storeMutex) ForKey(key string) *keyMutex {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if mutex, ok := m.entries[key]; ok {
+		return mutex
+	} else {
+		mutex := &keyMutex{&sync.RWMutex{}, key}
+		m.entries[key] = mutex
+		return mutex
+	}
+}
+
+type keyMutex struct {
+	*sync.RWMutex
+	key string
+}
+
+func (m *keyMutex) ReadCloser(rc io.ReadCloser) io.ReadCloser {
+	return &mutexReadCloser{rc, m}
+}
+
+func (m *keyMutex) WriteCloser(wc io.WriteCloser) io.WriteCloser {
+	return &mutexWriteCloser{wc, m}
+}
+
+func (m *keyMutex) Lock() {
+	if debugMutex {
+		log.Printf("Acquiring write lock for %#v", m)
+		log.Println(runtime.Caller(2))
+	}
+	m.RWMutex.Lock()
+}
+
+func (m *keyMutex) Unlock() {
+	if debugMutex {
+		log.Printf("Releasing write lock for %#v", m)
+		log.Println(runtime.Caller(2))
+	}
+	m.RWMutex.Unlock()
+}
+
+func (m *keyMutex) RLock() {
+	if debugMutex {
+		log.Printf("Acquiring read lock for %#v", m)
+		log.Println(runtime.Caller(2))
+	}
+	m.RWMutex.RLock()
+}
+
+func (m *keyMutex) RUnlock() {
+	if debugMutex {
+		log.Printf("Releasing read lock for %#v", m)
+		log.Println(runtime.Caller(2))
+	}
+	m.RWMutex.RUnlock()
+}
+
+type mutexReadCloser struct {
+	io.ReadCloser
+	m *keyMutex
+}
+
+func (mrc *mutexReadCloser) Close() error {
+	mrc.m.RUnlock()
+	return nil
+}
+
+type mutexWriteCloser struct {
+	io.WriteCloser
+	m *keyMutex
+}
+
+func (mwc *mutexWriteCloser) Close() error {
+	mwc.m.Unlock()
+	return nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -10,11 +10,32 @@ var ErrNotExists = errors.New("key does not exist in store")
 type Store interface {
 	Has(key string) bool
 	Delete(key string) error
-	Copy(dest, src string) error
-	WriteStream(key string, r io.Reader) error
-	ReadStream(key string) (io.ReadCloser, error)
+	Writer(key string) (io.WriteCloser, error)
+	Reader(key string) (io.ReadCloser, error)
 }
 
 func IsNotExists(e error) bool {
 	return e == ErrNotExists
+}
+
+func Copy(destKey, srcKey string, s Store) (int64, error) {
+	r, err := s.Reader(srcKey)
+	if err != nil {
+		return 0, err
+	}
+	w, err := s.Writer(destKey)
+	if err != nil {
+		return 0, err
+	}
+	n, err := io.Copy(w, r)
+	if err != nil {
+		return n, err
+	}
+	if err = r.Close(); err != nil {
+		return n, err
+	}
+	if err = w.Close(); err != nil {
+		return n, err
+	}
+	return n, nil
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,7 +2,9 @@ package store_test
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
+	"log"
 	"strings"
 	"testing"
 
@@ -20,29 +22,37 @@ var testData = map[string][]byte{
 }
 
 type storeTester struct {
-	s store.Store
+	store.Store
 }
 
 func (st *storeTester) Test(t *testing.T) {
-	// test writing
+	log.Printf("Testing writing")
 	for key, val := range testData {
 		for i := 0; i < 5; i++ {
-			if err := st.s.WriteStream(key, bytes.NewReader(val)); err != nil {
+			w, err := st.Writer(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = io.Copy(w, bytes.NewReader(val))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = w.Close(); err != nil {
 				t.Fatal(err)
 			}
 		}
 	}
 
-	// test has keys
+	log.Printf("Testing has")
 	for key := range testData {
-		require.True(t, st.s.Has(key))
-		require.False(t, st.s.Has(key+"doesn't exist"))
+		require.True(t, st.Store.Has(key))
+		require.False(t, st.Store.Has(key+"doesn't exist"))
 	}
 
-	// test reading
+	log.Printf("Testing reading")
 	for key, val := range testData {
 		for i := 0; i < 5; i++ {
-			r, err := st.s.ReadStream(key)
+			r, err := st.Store.Reader(key)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -50,7 +60,6 @@ func (st *storeTester) Test(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			if err := r.Close(); err != nil {
 				t.Fatal(err)
 			}
@@ -58,24 +67,25 @@ func (st *storeTester) Test(t *testing.T) {
 		}
 	}
 
-	// test copying
-	for key := range testData {
-		if err := st.s.Copy(key+"new", key); err != nil {
+	log.Printf("Testing copying")
+	for key, val := range testData {
+		n, err := store.Copy(key+"new", key, st.Store)
+		if err != nil {
 			t.Fatal(err)
-		} else {
-			require.True(t, st.s.Has(key+"new"))
+		}
+		require.True(t, st.Store.Has(key+"new"))
+		require.Equal(t, n, len(val))
+	}
+
+	log.Printf("Testing deleting")
+	for key := range testData {
+		if err := st.Store.Delete(key); err != nil {
+			t.Fatal(err)
 		}
 	}
 
-	// test deleting
+	log.Printf("Testing has not")
 	for key := range testData {
-		if err := st.s.Delete(key); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	// test doesn't have keys
-	for key := range testData {
-		require.False(t, st.s.Has(key))
+		require.False(t, st.Store.Has(key))
 	}
 }


### PR DESCRIPTION
Previously there was a single mutex in `MapStore` and `FileStore` that locked access to the contents. This didn't work for copies, as multiple locks were needed at the same time.

This also changes the Store API to return a `WriteCloser` for `Write` and a `ReadCloser` for `Read`. This is more go-like and easier to work with. 
