### PR TITLE
Use fnv64a instead of sha256 for cache keys

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -3,7 +3,6 @@ package httpcache
 import (
 	"bufio"
 	"bytes"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	vfs "gopkgs.com/vfs.v1"
+	"hash/fnv"
 )
 
 const (
@@ -190,8 +190,8 @@ func (c *Cache) Freshen(res *Resource, keys ...string) error {
 }
 
 func hashKey(key string) string {
-	h := sha256.New()
-	io.WriteString(h, key)
+	h := fnv.New64a()
+	h.Write([]byte(key))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 


### PR DESCRIPTION
I've done some benchmarks, and FNV is ~3 times faster than SHA256

https://gist.github.com/hectorj/8ac959c071d44ec4d718

I know it's only ~1 micro second by hashing, but it's also only a 3 lines change.