### PR TITLE
Update rainycape/vfs import path.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	vfs "gopkgs.com/vfs.v1"
+	"github.com/rainycape/vfs"
 )
 
 const (


### PR DESCRIPTION
The canonical import path of that package has changed, see https://github.com/rainycape/vfs/commit/a62fd22bcf7010946a44f6a1250a82c03110a14b. /cc @fiam