### PR TITLE
Set X-Cache header properly

### DIFF
--- a/cli/httpcache.go
+++ b/cli/httpcache.go
@@ -42,6 +42,8 @@ func init() {
 func main() {
 	proxy := &httputil.ReverseProxy{
 		Director: func(r *http.Request) {
+			r.URL.Scheme = "http"
+			r.URL.Host = "127.0.0.1:80"
 		},
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -116,8 +116,8 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	debugf("serving from cache")
+	res.Header().Set(CacheHeader, "HIT")
 	h.serveResource(res, rw, cReq)
-	rw.Header().Set(CacheHeader, "HIT")
 
 	if err := res.Close(); err != nil {
 		errorf("Error closing resource: %s", err.Error())
@@ -224,6 +224,7 @@ func (h *Handler) passUpstream(w http.ResponseWriter, r *cacheRequest) {
 
 	t := Clock()
 	debugf("passing request upstream")
+	rw.Header().Set(CacheHeader, "MISS")
 	h.upstream.ServeHTTP(rw, r.Request)
 	res := rw.Resource()
 	debugf("upstream responded in %s", Clock().Sub(t).String())
@@ -240,7 +241,6 @@ func (h *Handler) passUpstream(w http.ResponseWriter, r *cacheRequest) {
 		debugf("error calculating corrected age: %s", err.Error())
 	}
 
-	rw.Header().Set(CacheHeader, "MISS")
 	rw.Header().Set(ProxyDateHeader, Clock().Format(http.TimeFormat))
 	h.storeResource(res, r)
 }


### PR DESCRIPTION
First of all, thanks for a nice software!

I ran the cli example and thought X-Cache header was not set properly.
This pull request fix the problem.

Without this fix:

* the response for the first request does not have X-Cache header, which is wrong.
* the response for the second request has X-Cache header with value MISS, which is wrong.

```
$ curl -I -X GET http://localhost:8080
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 612
Content-Type: text/html
Date: Tue, 20 Oct 2015 16:11:08 GMT
Etag: "55f2cf52-264"
Last-Modified: Fri, 11 Sep 2015 12:55:46 GMT
Server: nginx/1.8.0

$ curl -I -X GET http://localhost:8080
HTTP/1.1 200 OK
Accept-Ranges: bytes
Age: 6
Content-Length: 612
Content-Type: text/html
Date: Tue, 20 Oct 2015 16:11:08 GMT
Etag: "55f2cf52-264"
Last-Modified: Fri, 11 Sep 2015 12:55:46 GMT
Proxy-Date: Tue, 20 Oct 2015 16:11:08 GMT
Server: nginx/1.8.0
Via: 1.1 httpcache
X-Cache: MISS

```

server logs

```
2015/10/21 01:11:08 [::1] "GET http://127.0.0.1:80/ HTTP/1.1" (OK) 612 MISS 1.970606ms
2015/10/21 01:11:13 [::1] "GET / HTTP/1.1" (OK) 612 HIT 704.282µs
```


With this fix:

* the response for the first request has X-Cache header with value MISS.
* the response for the second request have X-Cache header with value HIT.

```
$ curl -I -X GET http://localhost:8080
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 612
Content-Type: text/html
Date: Tue, 20 Oct 2015 16:17:42 GMT
Etag: "55f2cf52-264"
Last-Modified: Fri, 11 Sep 2015 12:55:46 GMT
Server: nginx/1.8.0
X-Cache: MISS

$ curl -I -X GET http://localhost:8080
HTTP/1.1 200 OK
Accept-Ranges: bytes
Age: 4
Content-Length: 612
Content-Type: text/html
Date: Tue, 20 Oct 2015 16:17:42 GMT
Etag: "55f2cf52-264"
Last-Modified: Fri, 11 Sep 2015 12:55:46 GMT
Proxy-Date: Tue, 20 Oct 2015 16:17:42 GMT
Server: nginx/1.8.0
Via: 1.1 httpcache
X-Cache: HIT

```

server logs

```
2015/10/21 01:17:42 [::1] "GET http://127.0.0.1:80/ HTTP/1.1" (OK) 612 MISS 1.126493ms
2015/10/21 01:17:45 [::1] "GET / HTTP/1.1" (OK) 612 HIT 607.92µs
```
