### PR TITLE
Reduce allocations in cachecontrol parsing

### DIFF
--- a/cachecontrol.go
+++ b/cachecontrol.go
@@ -29,7 +29,7 @@ func ParseCacheControl(input string) (CacheControl, error) {
 		var token string
 		switch input[pos] {
 		case '"':
-			token = readString(input, pos+1, "\"")
+			token = readUntil(input, pos+1, "\"")
 			pos += len(token) + 1
 		case ',', '\n', '\r', ' ', '\t':
 			continue
@@ -37,7 +37,7 @@ func ParseCacheControl(input string) (CacheControl, error) {
 			isValue = true
 			continue
 		default:
-			token = readString(input, pos, "\"\n\t\r ,=")
+			token = readUntil(input, pos, "\"\n\t\r ,=")
 			pos += len(token) - 1
 		}
 		if isValue {
@@ -52,16 +52,24 @@ func ParseCacheControl(input string) (CacheControl, error) {
 	return cc, nil
 }
 
-func readString(subject string, offset int, endchars string) string {
-	var accum []rune
-	for _, b := range subject[offset:] {
-		if strings.Index(endchars, string(b)) != -1 {
-			break
-		} else {
-			accum = append(accum, b)
+func contains(set string, r rune) bool {
+	for _, ch := range set {
+		if r == ch {
+			return true
 		}
 	}
-	return string(accum)
+	return false
+}
+
+func readUntil(subject string, offset int, endchars string) string {
+	rhs := offset
+	for _, ch := range subject[offset:] {
+		if contains(endchars, ch) {
+			break
+		}
+		rhs++
+	}
+	return subject[offset:rhs]
 }
 
 func (cc CacheControl) Get(key string) (string, bool) {

--- a/cachecontrol.go
+++ b/cachecontrol.go
@@ -52,19 +52,10 @@ func ParseCacheControl(input string) (CacheControl, error) {
 	return cc, nil
 }
 
-func contains(set string, r rune) bool {
-	for _, ch := range set {
-		if r == ch {
-			return true
-		}
-	}
-	return false
-}
-
 func readUntil(subject string, offset int, endchars string) string {
 	rhs := offset
 	for _, ch := range subject[offset:] {
-		if contains(endchars, ch) {
+		if strings.ContainsRune(endchars, ch) {
 			break
 		}
 		rhs++

--- a/cachecontrol.go
+++ b/cachecontrol.go
@@ -29,7 +29,11 @@ func ParseCacheControl(input string) (CacheControl, error) {
 		var token string
 		switch input[pos] {
 		case '"':
-			token = readUntil(input, pos+1, "\"")
+			if offset := strings.IndexAny(input[pos+1:], `"`); offset != -1 {
+				token = input[pos+1 : pos+1+offset]
+			} else {
+				token = input[pos+1:]
+			}
 			pos += len(token) + 1
 		case ',', '\n', '\r', ' ', '\t':
 			continue
@@ -37,7 +41,11 @@ func ParseCacheControl(input string) (CacheControl, error) {
 			isValue = true
 			continue
 		default:
-			token = readUntil(input, pos, "\"\n\t\r ,=")
+			if offset := strings.IndexAny(input[pos:], "\"\n\t\r ,="); offset != -1 {
+				token = input[pos : pos+offset]
+			} else {
+				token = input[pos:]
+			}
 			pos += len(token) - 1
 		}
 		if isValue {
@@ -50,17 +58,6 @@ func ParseCacheControl(input string) (CacheControl, error) {
 	}
 
 	return cc, nil
-}
-
-func readUntil(subject string, offset int, endchars string) string {
-	rhs := offset
-	for _, ch := range subject[offset:] {
-		if strings.ContainsRune(endchars, ch) {
-			break
-		}
-		rhs++
-	}
-	return subject[offset:rhs]
 }
 
 func (cc CacheControl) Get(key string) (string, bool) {


### PR DESCRIPTION
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkCacheControlParsing-4     3573          2119          -40.69%

benchmark                          old allocs     new allocs     delta
BenchmarkCacheControlParsing-4     61             4              -93.44%

benchmark                          old bytes     new bytes     delta
BenchmarkCacheControlParsing-4     976           432           -55.74%
```